### PR TITLE
Table extension and data asset creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Nothing.
+- Included the `create-data-asset` command to download and process the source data into one data asset file.
 
 ### Deprecated
 
@@ -20,4 +20,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Nothing.
+- Implemented the new `pystac` methods for the `table` extension.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
   - [proj](https://github.com/stac-extensions/projection/)
   - [scientific](https://github.com/stac-extensions/scientific/)
   - [item-assets](https://github.com/stac-extensions/item-assets/)
-  - [table](https://github.com/TomAugspurger/table)
+  - [table](https://github.com/stac-extensions/table)
 
 The Global Historical Climatology Network daily (GHCNd) is an integrated database of daily climate summaries from land surface stations across the globe. GHCNd is made up of daily climate records from numerous sources that have been integrated and subjected to a common suite of quality assurance reviews.
 
-This package builds a STAC Collection composed of one Item containing one data Asset. This data asset is assumed to be a concatenated version of all [individual GHCNd years](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/by_year/) left merged on [GHCNd stations](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/ghcnd-stations.txt) by `ID`. An example is given for [1763](tests/data/1763-1764.csv)
+This package builds a STAC Collection composed of one Item containing one data Asset. This data asset is assumed to be a concatenated version of all [individual GHCNd years](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/by_year/) left merged on [GHCNd stations](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/ghcnd-stations.txt) by `ID`. An example is given for [1763](tests/data/1763-1764.csv). Use `create-data-asset` command to perform these data asset creation steps.
 
 ## Examples
 
@@ -33,6 +33,8 @@ $ stac ghcnd create-item -s source -d destination
 $ stac ghcnd create-collection -d destination
 
 $ stac ghcnd populate-collection -s source -d destination
+
+$ stac ghcnd create-data-asset -d "./downloads" -u "./unzipped" -o "ghcnd.parquet"
 ```
 
-Use `stac ghcnd --help` to see all subcommands and options.
+Use `stac ghcnd --help <subcommand>` to see all subcommands and options.

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,12 @@ ignore_missing_imports = True
 
 [mypy-fsspec.*]
 ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True
+
+[mypy-pyarrow.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,4 +13,5 @@ sphinxcontrib-fulltoc
 sphinxcontrib-napoleon
 types-click
 types-pytz
+types-requests
 yapf

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,9 @@ packages = find_namespace:
 install_requires =
     pystac @ git+ssh://git@github.com/stac-utils/pystac.git
     stactools == 0.2.1
+    pandas == 1.3.4
+    pyarrow == 6.0.0
+    tqdm == 4.62.3
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,9 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
+    pystac @ git+ssh://git@github.com/stac-utils/pystac.git
     stactools == 0.2.1
+
 
 [options.packages.find]
 where = src

--- a/src/stactools/ghcnd/asset.py
+++ b/src/stactools/ghcnd/asset.py
@@ -1,0 +1,96 @@
+import gzip
+import os
+import shutil
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+from shapely.geometry import Point
+from tqdm import tqdm
+
+from stactools.ghcnd.constants import (
+    DATA_TABLE_COLUMNS,
+    STATION_TABLE_COLUMNS,
+    STATIONS_URL,
+    YEARS_URL,
+)
+
+
+class CreateDataAsset:
+    def __init__(self, download_folder: str, unzip_folder: str,
+                 output_path: str):
+        self.download_folder = download_folder
+        self.unzip_folder = unzip_folder
+        self.output_path = output_path
+
+        for folder in [download_folder, unzip_folder]:
+            if not os.path.exists(folder):
+                os.mkdir(folder)
+
+    def download(self, source: str) -> str:
+        """Download source file"""
+        response = requests.get(source, stream=True)
+        download_path = os.path.join(self.download_folder,
+                                     os.path.basename(source))
+
+        with open(download_path, "wb") as handle:
+            for data in tqdm(response.iter_content()):
+                handle.write(data)
+
+        return download_path
+
+    def unzip(self, source: str) -> str:
+        """Unzip a source file"""
+        unzip_fname = os.path.basename(source).replace(".gz", "")
+        unzip_path = os.path.join(self.unzip_folder, unzip_fname)
+        with gzip.open(source, 'rb') as f_in:
+            with open(unzip_path, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+        return unzip_path.replace(".gz", "")
+
+    def get_stations(self) -> pd.DataFrame:
+        """Get stations data"""
+        stations_fname = os.path.basename(STATIONS_URL)
+        stations_fwf = os.path.join(self.download_folder, stations_fname)
+        if not os.path.exists(stations_fwf):
+            self.download(STATIONS_URL)
+        stations_df = pd.read_fwf(
+            stations_fwf,
+            header=None,
+            names=[d["name"] for d in STATION_TABLE_COLUMNS])
+        stations_df["ID"] = stations_df.ID.astype(str)
+        return stations_df
+
+    def merge_stations(self, year_csv: str,
+                       stations_df: pd.DataFrame) -> pd.DataFrame:
+        """Merge yearly weather data from a csv file with a stations dataframe"""
+        year_df = pd.read_csv(year_csv,
+                              header=None,
+                              names=[d["name"] for d in DATA_TABLE_COLUMNS])
+        year_df["ID"] = year_df.ID.astype(str)
+        year_df = year_df.merge(stations_df, how="left")
+        year_df["geometry"] = year_df.apply(
+            lambda r: Point(r.LONGITUDE, r.LATITUDE), axis=1).astype(str)
+        return year_df
+
+    def create_data_asset(self, start_year: int, end_year: int) -> None:
+        stations_df = self.get_stations()
+        years = range(start_year, end_year + 1)
+
+        # Retrieve and append weather data for dates after last_date
+        for i, year in enumerate(years):
+            print(f"Processing {year}")
+            year_url = f"{YEARS_URL}{year}.csv.gz"
+            year_zip = self.download(year_url)
+            year_csv = self.unzip(year_zip)
+            year_df = self.merge_stations(year_csv, stations_df)
+            table = pa.Table.from_pandas(year_df)
+
+            if i == 0:
+                pqwriter = pq.ParquetWriter(self.output_path, table.schema)
+
+            pqwriter.write_table(table)
+
+        pqwriter.close()

--- a/src/stactools/ghcnd/commands.py
+++ b/src/stactools/ghcnd/commands.py
@@ -3,6 +3,7 @@ import logging
 import click
 
 from stactools.ghcnd import stac
+from stactools.ghcnd.asset import CreateDataAsset
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +98,57 @@ def create_ghcnd_command(cli):
         collection.normalize_hrefs(destination)
         collection.save(dest_href=destination)
         collection.validate()
+
+        return None
+
+    @ghcnd.command(
+        "create-data-asset",
+        short_help="Download and process the source data into the data asset.")
+    @click.option(
+        "-d",
+        "--downloads",
+        required=True,
+        help="Directory to hold downloads.",
+    )
+    @click.option(
+        "-u",
+        "--unzipped",
+        required=True,
+        help="Directory to hold unzipped files.",
+    )
+    @click.option(
+        "-o",
+        "--output_path",
+        required=True,
+        help="Path for output file (Parquet format).",
+    )
+    @click.option(
+        "-s",
+        "--start_year",
+        required=False,
+        help="Starting year to process (min: 1763, max: current year).",
+        default=1763)
+    @click.option("-e",
+                  "--end_year",
+                  required=False,
+                  help="Final year to process (min: 1763, max: current year).",
+                  default=2021)
+    def create_data_asset_command(downloads: str, unzipped: str,
+                                  output_path: str, start_year: int,
+                                  end_year: int):
+        """Download, unzip and process the yearly GHCNd data into one data asset.
+         Output is held in Parquet format.
+
+        Args:
+            downloads (str): Directory to hold downloads.
+            unzipped (str): Directory to hold unzipped files.
+            output_path (str): Path for output file (Parquet format).
+            start_year (int): Starting year to process (min: 1763, max: current year).
+            end_year (int): Final year to process (min: 1763, max: current_year).
+        """
+
+        data_asset = CreateDataAsset(downloads, unzipped, output_path)
+        data_asset.create_data_asset(start_year, end_year)
 
         return None
 

--- a/src/stactools/ghcnd/commands.py
+++ b/src/stactools/ghcnd/commands.py
@@ -50,14 +50,14 @@ def create_ghcnd_command(cli):
         "-d",
         "--destination",
         required=True,
-        help="An HREF for the STAC Collection.",
+        help="The output path for the STAC Item.",
     )
     def create_item_command(source: str, destination: str):
         """Creates a STAC Item
 
         Args:
             source (str): HREF of the Asset associated with the Item
-            destination (str): An HREF for the STAC Collection
+            destination (str): The output path for the STAC Item
         """
         item = stac.create_item(source)
         item.save_object(dest_href=destination)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -73,3 +73,23 @@ class CommandsTest(CliTestCase):
 
             jsons = [p for p in Path(tmp_dir).rglob('*.json')]
             self.assertEqual(len(jsons), 2)
+
+    def test_create_data_asset(self):
+        with TemporaryDirectory() as tmp_dir:
+
+            result = self.run_command([
+                "ghcnd", "create-data-asset", "-d",
+                os.path.join(tmp_dir, "downloads"), "-u",
+                os.path.join(tmp_dir, "downloads"), "-o",
+                os.path.join(tmp_dir, "ghcnd.parquet"), "-s", 1800, "-e", 1802
+            ])
+            self.assertEqual(result.exit_code,
+                             0,
+                             msg="\n{}".format(result.output))
+
+            gzs = [p for p in Path(tmp_dir).rglob('*.gz')]
+            self.assertEqual(len(gzs), 3)
+            csvs = [p for p in Path(tmp_dir).rglob('*.csv')]
+            self.assertEqual(len(csvs), 3)
+            parquets = [p for p in Path(tmp_dir).rglob('*.parquet')]
+            self.assertEqual(len(parquets), 1)


### PR DESCRIPTION
**Description:**
Implemented the `table` extension functionality newly introduced to `pystac`. Implemented a `create-data-asset` command to download and process source GHCNd data into a Parquet file, to be used as the data asset for the STAC Collection.

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
